### PR TITLE
fix: type declarations

### DIFF
--- a/src/StreamTransferInject.php
+++ b/src/StreamTransferInject.php
@@ -39,7 +39,7 @@ trait StreamTransferInject
     /**
      * {@inheritdoc}
      */
-    public function transfer(TransferInterface $responder, array $server)
+    public function transfer(TransferInterface $responder, array $server) : void
     {
         unset($responder);
         parent::transfer($this->responder, $server);

--- a/tests/Fake/Resource/Page/StreamArray.php
+++ b/tests/Fake/Resource/Page/StreamArray.php
@@ -13,7 +13,7 @@ class StreamArray extends ResourceObject
     {
         $this->body = [
             'msg' =>'hello world',
-            'stream' => fopen(__DIR__ . '/message.txt', 'r')
+            'stream' => fopen(__DIR__ . '/message.txt', 'rb')
         ];
 
         return $this;


### PR DESCRIPTION
`StreamTransferInject` を使った場合に、`BEAR\Resource\ResourceObject::transfer()` の型宣言と
不一致するため、Fatal error が起きる現象を修正しました。