### PR TITLE
PHP 8.5 support and code modernization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
+# Normalize line endings
+* text=auto eol=lf
+
 # Exclude build/test files from archive.
 /tests                           export-ignore
 /demo                            export-ignore

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,5 +9,5 @@ jobs:
   ci:
     uses: ray-di/.github/.github/workflows/continuous-integration.yml@v1
     with:
-      old_stable: '["8.1", "8.2", "8.3"]'
-      current_stable: 8.4
+      old_stable: '["8.1", "8.2", "8.3", "8.4"]'
+      current_stable: 8.5

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017-2024 Akihito Koriyama <akihito.koriyama@gmail.com>
+Copyright (c) 2017-2025 Akihito Koriyama <akihito.koriyama@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Annotation/Stream.php
+++ b/src/Annotation/Stream.php
@@ -7,7 +7,7 @@ namespace BEAR\Streamer\Annotation;
 use Attribute;
 use Ray\Di\Di\Qualifier;
 
-#[Attribute(Attribute::TARGET_METHOD)]
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_PARAMETER)]
 #[Qualifier]
 final class Stream
 {

--- a/src/StreamTransferInject.php
+++ b/src/StreamTransferInject.php
@@ -17,15 +17,15 @@ trait StreamTransferInject
 
     /** @return ResourceObject */
     #[Inject]
-    #[Stream]
-    public function setRenderer(RenderInterface $render)
+    public function setRenderer(#[Stream]
+    RenderInterface $render,)
     {
         return parent::setRenderer($render);
     }
 
     #[Inject]
-    #[Stream]
-    public function setTransfer(TransferInterface $responder): void
+    public function setTransfer(#[Stream]
+    TransferInterface $responder,): void
     {
         $this->responder = $responder;
     }

--- a/src/Streamer.php
+++ b/src/Streamer.php
@@ -25,9 +25,10 @@ final class Streamer implements StreamerInterface
     private array $streams = [];
 
     /** @param resource $stream */
-    #[Stream]
-    public function __construct(private $stream)
-    {
+    public function __construct(
+        #[Stream]
+        private $stream,
+    ) {
     }
 
     /** @param resource[] $streams */
@@ -54,7 +55,7 @@ final class Streamer implements StreamerInterface
         foreach ($bodies as $body) {
             fwrite($stream, (string) $body);
             $index = array_shift($list);
-            if (isset($this->streams[$index])) {
+            if ($index !== null && isset($this->streams[$index])) {
                 $popStream = $this->streams[$index];
                 rewind($popStream);
                 stream_copy_to_stream($popStream, $stream);

--- a/tests/IntegrateTest.php
+++ b/tests/IntegrateTest.php
@@ -19,6 +19,7 @@ use function method_exists;
 use function ob_get_clean;
 use function ob_start;
 use function rewind;
+use function str_replace;
 use function stream_get_contents;
 
 class IntegrateTest extends TestCase
@@ -83,7 +84,8 @@ class IntegrateTest extends TestCase
         $stream = $this->streamer->getStream((string) $view);
         rewind($stream);
         $view = stream_get_contents($stream);
-        $this->assertSame($expected, $view);
+        assert($view !== false);
+        $this->assertSameNormalized($expected, $view);
     }
 
     public function testTrait(): void
@@ -94,6 +96,7 @@ class IntegrateTest extends TestCase
         ob_start();
         $page->onGet()->transfer($dummy, []);
         $output = ob_get_clean();
+        assert($output !== false);
         $headers = self::$headers;
         $expected = [
             [
@@ -102,11 +105,17 @@ class IntegrateTest extends TestCase
             ],
         ];
         $this->assertSame($expected, $headers);
-        $this->assertSame('{
+        $this->assertSameNormalized('{
     "msg": "hello world",
     "stream": "Konichiwa stream !
 "
 }
 ', $output);
+    }
+
+    private function assertSameNormalized(string $expected, string $actual): void
+    {
+        $normalize = static fn (string $str): string => str_replace(["\r\n", "\r"], "\n", $str);
+        $this->assertSame($normalize($expected), $normalize($actual));
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,9 +2,4 @@
 
 declare(strict_types=1);
 
-use Koriym\Attributes\AttributeReader;
-use Ray\ServiceLocator\ServiceLocator;
-
 require dirname(__DIR__) . '/vendor/autoload.php';
-
-ServiceLocator::setReader(new AttributeReader());


### PR DESCRIPTION
## Summary

Updates BEAR.Streamer for PHP 8.5 support and removes deprecated dependencies.

## Changes

- Add PHP 8.5 to CI test matrix
- Remove deprecated AttributeReader usage
- Modernize Stream qualifier usage (internal implementation)

All tests passing on PHP 8.1-8.5.

## Summary by Sourcery

Add PHP 8.5 compatibility and modernize stream attribute usage.

Enhancements:
- Update stream qualifier to support parameter-level attributes and modern constructor attribute placement.
- Remove reliance on deprecated attribute reader and service locator bootstrap wiring.

CI:
- Extend CI test matrix to treat PHP 8.5 as current stable and move 8.4 to old stable.